### PR TITLE
Set merge output to sensitive

### DIFF
--- a/modules/merge/outputs.tf
+++ b/modules/merge/outputs.tf
@@ -1,4 +1,5 @@
 output "container_definitions" {
   description = "A list of container definitions in JSON format that describe the different containers that make up your task"
   value       = format("[%s]", join(",", var.container_definitions))
+  sensitive   = true
 }


### PR DESCRIPTION
Upon upgrading to Terraform 0.15, using `"mongodb/terraform-aws-ecs-task-definition/modules/merge"` resulted in plan failures due to the use of _sensitive_ variables in the `container_definitions` output.